### PR TITLE
Add dots to headers gpl3

### DIFF
--- a/gnu-gpl-v3.0.md
+++ b/gnu-gpl-v3.0.md
@@ -1,4 +1,4 @@
-GNU General Public License
+GNU GENERAL PUBLIC LICENSE
 ==========================
 
 _Version 3, 29 June 2007_  

--- a/gnu-gpl-v3.0.md
+++ b/gnu-gpl-v3.0.md
@@ -65,7 +65,7 @@ The precise terms and conditions for copying, distribution and modification foll
 
 ## TERMS AND CONDITIONS
 
-### 0. Definitions
+### 0. Definitions.
 
 “This License” refers to version 3 of the GNU General Public License.
 
@@ -102,7 +102,7 @@ licensees may convey the work under this License, and how to view a copy of this
 License. If the interface presents a list of user commands or options, such as a
 menu, a prominent item in the list meets this criterion.
 
-### 1. Source Code
+### 1. Source Code.
 
 The “source code” for a work means the preferred form of the work for
 making modifications to it. “Object code” means any non-source form of a
@@ -139,7 +139,7 @@ automatically from other parts of the Corresponding Source.
 
 The Corresponding Source for a work in source code form is that same work.
 
-### 2. Basic Permissions
+### 2. Basic Permissions.
 
 All rights granted under this License are granted for the term of copyright on the
 Program, and are irrevocable provided the stated conditions are met. This License
@@ -161,7 +161,7 @@ with you.
 Conveying under any other circumstances is permitted solely under the conditions
 stated below. Sublicensing is not allowed; section 10 makes it unnecessary.
 
-### 3. Protecting Users' Legal Rights From Anti-Circumvention Law
+### 3. Protecting Users' Legal Rights From Anti-Circumvention Law.
 
 No covered work shall be deemed part of an effective technological measure under any
 applicable law fulfilling obligations under article 11 of the WIPO copyright treaty
@@ -175,7 +175,7 @@ intention to limit operation or modification of the work as a means of enforcing
 against the work's users, your or third parties' legal rights to forbid circumvention
 of technological measures.
 
-### 4. Conveying Verbatim Copies
+### 4. Conveying Verbatim Copies.
 
 You may convey verbatim copies of the Program's source code as you receive it, in any
 medium, provided that you conspicuously and appropriately publish on each copy an
@@ -187,7 +187,7 @@ this License along with the Program.
 You may charge any price or no price for each copy that you convey, and you may offer
 support or warranty protection for a fee.
 
-### 5. Conveying Modified Source Versions
+### 5. Conveying Modified Source Versions.
 
 You may convey a work based on the Program, or the modifications to produce it from
 the Program, in the form of source code under the terms of section 4, provided that
@@ -216,7 +216,7 @@ copyright are not used to limit the access or legal rights of the compilation's 
 beyond what the individual works permit. Inclusion of a covered work in an aggregate
 does not cause this License to apply to the other parts of the aggregate.
 
-### 6. Conveying Non-Source Forms
+### 6. Conveying Non-Source Forms.
 
 You may convey a covered work in object code form under the terms of sections 4 and
 5, provided that you also convey the machine-readable Corresponding Source under the
@@ -296,7 +296,7 @@ this section must be in a format that is publicly documented (and with an
 implementation available to the public in source code form), and must require no
 special password or key for unpacking, reading or copying.
 
-### 7. Additional Terms
+### 7. Additional Terms.
 
 “Additional permissions” are terms that supplement the terms of this
 License by making exceptions from one or more of its conditions. Additional
@@ -350,7 +350,7 @@ Additional terms, permissive or non-permissive, may be stated in the form of a
 separately written license, or stated as exceptions; the above requirements apply
 either way.
 
-### 8. Termination
+### 8. Termination.
 
 You may not propagate or modify a covered work except as expressly provided under
 this License. Any attempt otherwise to propagate or modify it is void, and will
@@ -374,7 +374,7 @@ parties who have received copies or rights from you under this License. If your
 rights have been terminated and not permanently reinstated, you do not qualify to
 receive new licenses for the same material under section 10.
 
-### 9. Acceptance Not Required for Having Copies
+### 9. Acceptance Not Required for Having Copies.
 
 You are not required to accept this License in order to receive or run a copy of the
 Program. Ancillary propagation of a covered work occurring solely as a consequence of
@@ -384,7 +384,7 @@ propagate or modify any covered work. These actions infringe copyright if you do
 accept this License. Therefore, by modifying or propagating a covered work, you
 indicate your acceptance of this License to do so.
 
-### 10. Automatic Licensing of Downstream Recipients
+### 10. Automatic Licensing of Downstream Recipients.
 
 Each time you convey a covered work, the recipient automatically receives a license
 from the original licensors, to run, modify and propagate that work, subject to this
@@ -407,7 +407,7 @@ initiate litigation (including a cross-claim or counterclaim in a lawsuit) alleg
 that any patent claim is infringed by making, using, selling, offering for sale, or
 importing the Program or any portion of it.
 
-### 11. Patents
+### 11. Patents.
 
 A “contributor” is a copyright holder who authorizes use under this
 License of the Program or a work on which the Program is based. The work thus
@@ -468,7 +468,7 @@ Nothing in this License shall be construed as excluding or limiting any implied
 license or other defenses to infringement that may otherwise be available to you
 under applicable patent law.
 
-### 12. No Surrender of Others' Freedom
+### 12. No Surrender of Others' Freedom.
 
 If conditions are imposed on you (whether by court order, agreement or otherwise)
 that contradict the conditions of this License, they do not excuse you from the
@@ -479,7 +479,7 @@ agree to terms that obligate you to collect a royalty for further conveying from
 those to whom you convey the Program, the only way you could satisfy both those terms
 and this License would be to refrain entirely from conveying the Program.
 
-### 13. Use with the GNU Affero General Public License
+### 13. Use with the GNU Affero General Public License.
 
 Notwithstanding any other provision of this License, you have permission to link or
 combine any covered work with a work licensed under version 3 of the GNU Affero
@@ -488,7 +488,7 @@ The terms of this License will continue to apply to the part which is the covere
 work, but the special requirements of the GNU Affero General Public License, section
 13, concerning interaction through a network will apply to the combination as such.
 
-### 14. Revised Versions of this License
+### 14. Revised Versions of this License.
 
 The Free Software Foundation may publish revised and/or new versions of the GNU
 General Public License from time to time. Such new versions will be similar in spirit
@@ -510,7 +510,7 @@ Later license versions may give you additional or different permissions. However
 additional obligations are imposed on any author or copyright holder as a result of
 your choosing to follow a later version.
 
-### 15. Disclaimer of Warranty
+### 15. Disclaimer of Warranty.
 
 THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
 EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
@@ -520,7 +520,7 @@ MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE
 QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE
 DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
 
-### 16. Limitation of Liability
+### 16. Limitation of Liability.
 
 IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY
 COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS
@@ -531,7 +531,7 @@ OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERA
 WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGES.
 
-### 17. Interpretation of Sections 15 and 16
+### 17. Interpretation of Sections 15 and 16.
 
 If the disclaimer of warranty and limitation of liability provided above cannot be
 given local legal effect according to their terms, reviewing courts shall apply local


### PR DESCRIPTION
Here we have: http://www.gnu.org/licenses/gpl.html

`0. Definitions.` in MD version — not `0. Definitions`

``` bash
sed -i 's/^\(###.*[^\.]\)$/\1./' gnu-gpl-v3.0.md
```
