### PR TITLE
Added the WAIVER associated with the UNLICENSE

### DIFF
--- a/unlicense-waiver.md
+++ b/unlicense-waiver.md
@@ -1,0 +1,5 @@
+I dedicate any and all copyright interest in this software to the
+public domain. I make this dedication for the benefit of the public at
+large and to the detriment of my heirs and successors. I intend this
+dedication to be an overt act of relinquishment in perpetuity of all
+present and future rights to this software under copyright law.


### PR DESCRIPTION
For the purposes of this explanation, instances of the word "Unlicense" shall
refer to the designers of the document. "unlicense" shall refer to the actual
unlicense document.

Unlicense makes the recommendation that any major contributors to a project
covered by the unlicense should digitally sign a waiver. They even go so far as
to provide a simple template waiver paragraph, which should be included as its
own standalone file.

I have added that particular file.
