### PR TITLE
Fix bug by changing formatting

### DIFF
--- a/apache-v2.0.md
+++ b/apache-v2.0.md
@@ -89,15 +89,15 @@ You may reproduce and distribute copies of the Work or Derivative Works thereof
 in any medium, with or without modifications, and in Source or Object form,
 provided that You meet the following conditions:
 
-* **(a)** You must give any other recipients of the Work or Derivative Works a copy of
+* **a)** You must give any other recipients of the Work or Derivative Works a copy of
 this License; and
-* **(b)** You must cause any modified files to carry prominent notices stating that You
+* **b)** You must cause any modified files to carry prominent notices stating that You
 changed the files; and
-* **(c)** You must retain, in the Source form of any Derivative Works that You distribute,
+* **c)** You must retain, in the Source form of any Derivative Works that You distribute,
 all copyright, patent, trademark, and attribution notices from the Source form
 of the Work, excluding those notices that do not pertain to any part of the
 Derivative Works; and
-* **(d)** If the Work includes a “NOTICE” text file as part of its distribution, then any
+* **d)** If the Work includes a “NOTICE” text file as part of its distribution, then any
 Derivative Works that You distribute must include a readable copy of the
 attribution notices contained within such NOTICE file, excluding those notices
 that do not pertain to any part of the Derivative Works, in at least one of the


### PR DESCRIPTION
This PR changes the 4th section’s listing from `(a) […] (b)` and so on to  simply `a) […] b)` because of a bug in some Markdown renderers. Well, a feature, I guess.

`(c)`, even in a list, is converted to the copyright symbol (`&copy;`) specifically on Hugo (which is a static site generator). Now, I don’t know how about you, but I think that converting `(c)` to `©` would create some legal issues. Or, perhaps, it’d just look like garbage. In either way, this is not ideal.

Example:

![image](https://user-images.githubusercontent.com/11616378/31775460-5d6af4ea-b4f1-11e7-886d-c770f59054e6.png)
